### PR TITLE
feat: 複数機種・全設定対応のシミュレーション機能を実装

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,15 +5,25 @@ import Header from '@/components/Header';
 import Footer from '@/components/Footer';
 import Graphs from '@/components/Graphs';
 import Menu from '@/components/Menu';
+import { MachineId, SettingLevel } from '@/lib/constants/slotSettings';
 
 export default function Home() {
   const [game, setGame] = useState<number>(8000);
+  const [machineId, setMachineId] = useState<MachineId>('aim');
+  const [setting, setSetting] = useState<SettingLevel>(6);
 
   return (
     <>
       <Header />
-      <Menu game={game} setGame={setGame} />
-      <Graphs game={game} />
+      <Menu
+        game={game}
+        setGame={setGame}
+        machineId={machineId}
+        setMachineId={setMachineId}
+        setting={setting}
+        setSetting={setSetting}
+      />
+      <Graphs game={game} machineId={machineId} setting={setting} />
       <Footer />
     </>
   );

--- a/components/Graphs/index.tsx
+++ b/components/Graphs/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Line } from 'react-chartjs-2';
 import {
   Chart,
@@ -14,19 +14,24 @@ import {
   RANDOM_MAX,
   COINS_PER_GAME,
   YEN_PER_COIN,
-  SYMBOL_CONFIGS,
-  getSymbolFromRandom,
+  SYMBOL_DISPLAY_NAMES,
   MIN_GAME_COUNT,
   MAX_GAME_COUNT,
+  MachineId,
+  SettingLevel,
+  generateRangeTable,
+  getSymbolFromRandom,
 } from '@/lib/constants/slotSettings';
 
 Chart.register(LineController, LinearScale, PointElement, LineElement);
 
 type Props = {
   game: number;
+  machineId: MachineId;
+  setting: SettingLevel;
 };
 
-export default function Graphs({ game }: Props) {
+export default function Graphs({ game, machineId, setting }: Props) {
   const [totalCoins, setTotalCoins] = useState(0);
   const [results, setResults] = useState<{ x: number; y: number }[]>([]);
   const [bbCount, setBBCount] = useState(0);
@@ -36,6 +41,11 @@ export default function Graphs({ game }: Props) {
   const [grapeCount, setGrapeCount] = useState(0);
   const [missCount, setMissCount] = useState(0);
   const [error, setError] = useState<string | null>(null);
+
+  const rangeTable = useMemo(
+    () => generateRangeTable(machineId, setting),
+    [machineId, setting]
+  );
 
   function gcd(a: number, b: number): number {
     if (!b) {
@@ -98,27 +108,24 @@ export default function Graphs({ game }: Props) {
     for (let i = 0; i < game; i++) {
       newCoins -= COINS_PER_GAME;
       const randomNum = Math.floor(Math.random() * RANDOM_MAX + 1);
-      const symbol = getSymbolFromRandom(randomNum);
+      const result = getSymbolFromRandom(randomNum, rangeTable);
 
-      switch (symbol) {
+      newCoins += result.payout;
+
+      switch (result.symbol) {
         case 'BB':
-          newCoins += SYMBOL_CONFIGS.BB.payout;
           bb++;
           break;
         case 'RB':
-          newCoins += SYMBOL_CONFIGS.RB.payout;
           rb++;
           break;
         case 'CHERRY':
-          newCoins += SYMBOL_CONFIGS.CHERRY.payout;
           cherry++;
           break;
         case 'REPLAY':
-          newCoins += SYMBOL_CONFIGS.REPLAY.payout;
           replay++;
           break;
         case 'GRAPE':
-          newCoins += SYMBOL_CONFIGS.GRAPE.payout;
           grape++;
           break;
         case 'MISS':
@@ -222,12 +229,12 @@ export default function Graphs({ game }: Props) {
           </thead>
           <tbody>
             <tr>
-              <th>{SYMBOL_CONFIGS.BB.displayName}</th>
+              <th>{SYMBOL_DISPLAY_NAMES.BB}</th>
               <td>{bbCount}</td>
               <td>{fraction(bbCount, totalCount)}</td>
             </tr>
             <tr>
-              <th>{SYMBOL_CONFIGS.RB.displayName}</th>
+              <th>{SYMBOL_DISPLAY_NAMES.RB}</th>
               <td>{rbCount}</td>
               <td>{fraction(rbCount, totalCount)}</td>
             </tr>
@@ -237,22 +244,22 @@ export default function Graphs({ game }: Props) {
               <td>{fraction(rbCount + bbCount, totalCount)}</td>
             </tr>
             <tr>
-              <th>{SYMBOL_CONFIGS.CHERRY.displayName}</th>
+              <th>{SYMBOL_DISPLAY_NAMES.CHERRY}</th>
               <td>{cherryCount}</td>
               <td>{fraction(cherryCount, totalCount)}</td>
             </tr>
             <tr>
-              <th>{SYMBOL_CONFIGS.REPLAY.displayName}</th>
+              <th>{SYMBOL_DISPLAY_NAMES.REPLAY}</th>
               <td>{replayCount}</td>
               <td>{fraction(replayCount, totalCount)}</td>
             </tr>
             <tr>
-              <th>{SYMBOL_CONFIGS.GRAPE.displayName}</th>
+              <th>{SYMBOL_DISPLAY_NAMES.GRAPE}</th>
               <td>{grapeCount}</td>
               <td>{fraction(grapeCount, totalCount)}</td>
             </tr>
             <tr>
-              <th>{SYMBOL_CONFIGS.MISS.displayName}</th>
+              <th>{SYMBOL_DISPLAY_NAMES.MISS}</th>
               <td>{missCount}</td>
               <td>{fraction(missCount, totalCount)}</td>
             </tr>

--- a/components/Menu/index.tsx
+++ b/components/Menu/index.tsx
@@ -1,15 +1,39 @@
 'use client';
 
 import StyledMenu from './styled';
+import {
+  MachineId,
+  SettingLevel,
+  MACHINE_LIST,
+} from '@/lib/constants/slotSettings';
 
 type Props = {
   game: number;
   setGame: (value: number) => void;
+  machineId: MachineId;
+  setMachineId: (value: MachineId) => void;
+  setting: SettingLevel;
+  setSetting: (value: SettingLevel) => void;
 };
 
-export default function Menu({ game, setGame }: Props) {
+export default function Menu({
+  game,
+  setGame,
+  machineId,
+  setMachineId,
+  setting,
+  setSetting,
+}: Props) {
   const handleGameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setGame(Number(e.target.value));
+  };
+
+  const handleMachineChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setMachineId(e.target.value as MachineId);
+  };
+
+  const handleSettingChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setSetting(Number(e.target.value) as SettingLevel);
   };
 
   return (
@@ -20,43 +44,32 @@ export default function Menu({ game, setGame }: Props) {
           <tr>
             <th>機種</th>
             <td>
-              <select id="machine-type" defaultValue="s-Im">
-                <option value="s-Im">Sアイムジャグラー</option>
-                <option disabled value="my5">
-                  マイジャグラーV
-                </option>
-                <option disabled value="happy">
-                  ハッピージャグラー2
-                </option>
-                <option disabled value="funky">
-                  ファンキージャグラー2
-                </option>
-                <option disabled value="gogo">
-                  ゴーゴージャグラー3
-                </option>
+              <select
+                id="machine-type"
+                value={machineId}
+                onChange={handleMachineChange}
+              >
+                {MACHINE_LIST.map((machine) => (
+                  <option key={machine.id} value={machine.id}>
+                    {machine.name}
+                  </option>
+                ))}
               </select>
             </td>
           </tr>
           <tr>
             <th>設定</th>
             <td>
-              <select id="setting-level" defaultValue="6">
-                <option disabled value="1">
-                  1
-                </option>
-                <option disabled value="2">
-                  2
-                </option>
-                <option disabled value="3">
-                  3
-                </option>
-                <option disabled value="4">
-                  4
-                </option>
-                <option disabled value="5">
-                  5
-                </option>
-                <option value="6">6</option>
+              <select
+                id="setting-level"
+                value={setting}
+                onChange={handleSettingChange}
+              >
+                {([1, 2, 3, 4, 5, 6] as SettingLevel[]).map((level) => (
+                  <option key={level} value={level}>
+                    {level}
+                  </option>
+                ))}
               </select>
             </td>
           </tr>

--- a/lib/constants/slotSettings.ts
+++ b/lib/constants/slotSettings.ts
@@ -9,75 +9,207 @@ export const COINS_PER_GAME = 3;
 // 1枚あたりの円換算レート
 export const YEN_PER_COIN = 20;
 
+// 入力値の検証用定数
+export const MIN_GAME_COUNT = 1;
+export const MAX_GAME_COUNT = 100000;
+export const DEFAULT_GAME_COUNT = 8000;
+
 // 役の種類
 export type SymbolType = 'BB' | 'RB' | 'CHERRY' | 'REPLAY' | 'GRAPE' | 'MISS';
 
-// 役の設定（設定6の確率）
-export interface SymbolConfig {
+// 設定値（1-6）
+export type SettingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+// 機種ID
+export type MachineId = 'aim' | 'myJuggler' | 'funky';
+
+// 払い出し枚数（全機種共通）
+export const PAYOUTS: Record<Exclude<SymbolType, 'MISS'>, number> = {
+  BB: 251,
+  RB: 95,
+  GRAPE: 8,
+  CHERRY: 2,
+  REPLAY: 3,
+};
+
+// 役の表示名
+export const SYMBOL_DISPLAY_NAMES: Record<SymbolType, string> = {
+  BB: 'BB',
+  RB: 'RB',
+  CHERRY: 'チェリー',
+  REPLAY: 'リプレイ',
+  GRAPE: 'ぶどう',
+  MISS: 'ハズレ',
+};
+
+// 確率データの型（1/X形式のXの値）
+export interface ProbabilityData {
+  singleBB: number;    // 単独BB
+  cherryBB: number;    // チェリーBB
+  singleRB: number;    // 単独RB
+  cherryRB: number;    // チェリーRB
+  grape: number;       // ぶどう
+  replay: number;      // リプレイ
+  cherry: number;      // チェリー（非重複）
+}
+
+// 機種情報
+export interface MachineInfo {
+  id: MachineId;
   name: string;
-  displayName: string;
+  settings: Record<SettingLevel, ProbabilityData>;
+}
+
+// アイムジャグラー
+const aimJuggler: MachineInfo = {
+  id: 'aim',
+  name: 'Sアイムジャグラー',
+  settings: {
+    1: { singleBB: 394.8, cherryBB: 888.1, singleRB: 630.2, cherryRB: 1456.4, grape: 6.02, replay: 7.3, cherry: 35.2 },
+    2: { singleBB: 390.1, cherryBB: 873.8, singleRB: 574.9, cherryRB: 1310.7, grape: 6.02, replay: 7.3, cherry: 35.2 },
+    3: { singleBB: 390.1, cherryBB: 873.8, singleRB: 474.9, cherryRB: 1092.3, grape: 6.02, replay: 7.3, cherry: 35.2 },
+    4: { singleBB: 374.5, cherryBB: 840.2, singleRB: 452.0, cherryRB: 1040.3, grape: 6.02, replay: 7.3, cherry: 35.1 },
+    5: { singleBB: 374.5, cherryBB: 840.2, singleRB: 364.1, cherryRB: 851.1, grape: 6.02, replay: 7.3, cherry: 35.0 },
+    6: { singleBB: 368.2, cherryBB: 829.1, singleRB: 364.1, cherryRB: 851.1, grape: 5.78, replay: 7.3, cherry: 34.9 },
+  },
+};
+
+// マイジャグラーV
+const myJugglerV: MachineInfo = {
+  id: 'myJuggler',
+  name: 'マイジャグラーV',
+  settings: {
+    1: { singleBB: 390.1, cherryBB: 910.2, singleRB: 668.7, cherryRB: 1057.0, grape: 5.90, replay: 7.3, cherry: 38.5 },
+    2: { singleBB: 385.5, cherryBB: 910.2, singleRB: 630.2, cherryRB: 993.0, grape: 5.86, replay: 7.3, cherry: 38.4 },
+    3: { singleBB: 376.6, cherryBB: 910.2, singleRB: 574.9, cherryRB: 910.2, grape: 5.82, replay: 7.3, cherry: 38.3 },
+    4: { singleBB: 356.2, cherryBB: 873.8, singleRB: 481.9, cherryRB: 780.2, grape: 5.78, replay: 7.3, cherry: 38.2 },
+    5: { singleBB: 334.4, cherryBB: 851.1, singleRB: 414.9, cherryRB: 682.7, grape: 5.74, replay: 7.3, cherry: 38.1 },
+    6: { singleBB: 321.3, cherryBB: 799.2, singleRB: 334.4, cherryRB: 720.2, grape: 5.66, replay: 7.3, cherry: 38.0 },
+  },
+};
+
+// ファンキージャグラー2
+const funkyJuggler2: MachineInfo = {
+  id: 'funky',
+  name: 'ファンキージャグラー2',
+  settings: {
+    1: { singleBB: 372.4, cherryBB: 936.2, singleRB: 682.7, cherryRB: 1236.5, grape: 6.10, replay: 7.3, cherry: 37.5 },
+    2: { singleBB: 362.1, cherryBB: 910.2, singleRB: 630.2, cherryRB: 1149.8, grape: 6.08, replay: 7.3, cherry: 37.4 },
+    3: { singleBB: 358.1, cherryBB: 897.8, singleRB: 565.0, cherryRB: 1040.3, grape: 6.06, replay: 7.3, cherry: 37.3 },
+    4: { singleBB: 348.6, cherryBB: 873.8, singleRB: 496.5, cherryRB: 923.0, grape: 6.04, replay: 7.3, cherry: 37.2 },
+    5: { singleBB: 324.4, cherryBB: 819.2, singleRB: 458.3, cherryRB: 862.3, grape: 6.00, replay: 7.3, cherry: 37.1 },
+    6: { singleBB: 307.7, cherryBB: 771.0, singleRB: 402.1, cherryRB: 753.3, grape: 5.85, replay: 7.3, cherry: 36.5 },
+  },
+};
+
+// 全機種データ
+export const MACHINES: Record<MachineId, MachineInfo> = {
+  aim: aimJuggler,
+  myJuggler: myJugglerV,
+  funky: funkyJuggler2,
+};
+
+// 機種リスト（UI表示用）
+export const MACHINE_LIST: { id: MachineId; name: string }[] = [
+  { id: 'aim', name: 'Sアイムジャグラー' },
+  { id: 'myJuggler', name: 'マイジャグラーV' },
+  { id: 'funky', name: 'ファンキージャグラー2' },
+];
+
+// 確率（1/X）から乱数範囲の幅を計算
+function probabilityToRange(probability: number): number {
+  return Math.round(RANDOM_MAX / probability);
+}
+
+// シミュレーション用の乱数範囲テーブルを生成
+export interface SymbolRange {
+  symbol: SymbolType;
   rangeStart: number;
   rangeEnd: number;
   payout: number;
 }
 
-// Sアイムジャグラー 設定6の確率テーブル
-export const SYMBOL_CONFIGS: Record<SymbolType, SymbolConfig> = {
-  BB: {
-    name: 'BB',
-    displayName: 'BB',
-    rangeStart: 1,
-    rangeEnd: 255,
-    payout: 252,
-  },
-  RB: {
-    name: 'RB',
-    displayName: 'RB',
-    rangeStart: 256,
-    rangeEnd: 511,
-    payout: 96,
-  },
-  CHERRY: {
-    name: 'CHERRY',
-    displayName: 'チェリー',
-    rangeStart: 512,
-    rangeEnd: 2592,
-    payout: 2,
-  },
-  REPLAY: {
-    name: 'REPLAY',
-    displayName: 'リプレイ',
-    rangeStart: 2593,
-    rangeEnd: 11571,
-    payout: 3,
-  },
-  GRAPE: {
-    name: 'GRAPE',
-    displayName: 'ぶどう',
-    rangeStart: 11572,
-    rangeEnd: 22871,
-    payout: 8,
-  },
-  MISS: {
-    name: 'MISS',
-    displayName: 'ハズレ',
-    rangeStart: 22872,
+export function generateRangeTable(
+  machineId: MachineId,
+  setting: SettingLevel
+): SymbolRange[] {
+  const machine = MACHINES[machineId];
+  const prob = machine.settings[setting];
+
+  const ranges: SymbolRange[] = [];
+  let currentStart = 1;
+
+  // BB（単独BB + チェリーBB）
+  const bbRange = probabilityToRange(prob.singleBB) + probabilityToRange(prob.cherryBB);
+  ranges.push({
+    symbol: 'BB',
+    rangeStart: currentStart,
+    rangeEnd: currentStart + bbRange - 1,
+    payout: PAYOUTS.BB,
+  });
+  currentStart += bbRange;
+
+  // RB（単独RB + チェリーRB）
+  const rbRange = probabilityToRange(prob.singleRB) + probabilityToRange(prob.cherryRB);
+  ranges.push({
+    symbol: 'RB',
+    rangeStart: currentStart,
+    rangeEnd: currentStart + rbRange - 1,
+    payout: PAYOUTS.RB,
+  });
+  currentStart += rbRange;
+
+  // チェリー（非重複）
+  const cherryRange = probabilityToRange(prob.cherry);
+  ranges.push({
+    symbol: 'CHERRY',
+    rangeStart: currentStart,
+    rangeEnd: currentStart + cherryRange - 1,
+    payout: PAYOUTS.CHERRY,
+  });
+  currentStart += cherryRange;
+
+  // リプレイ
+  const replayRange = probabilityToRange(prob.replay);
+  ranges.push({
+    symbol: 'REPLAY',
+    rangeStart: currentStart,
+    rangeEnd: currentStart + replayRange - 1,
+    payout: PAYOUTS.REPLAY,
+  });
+  currentStart += replayRange;
+
+  // ぶどう
+  const grapeRange = probabilityToRange(prob.grape);
+  ranges.push({
+    symbol: 'GRAPE',
+    rangeStart: currentStart,
+    rangeEnd: currentStart + grapeRange - 1,
+    payout: PAYOUTS.GRAPE,
+  });
+  currentStart += grapeRange;
+
+  // ハズレ（余事象）
+  ranges.push({
+    symbol: 'MISS',
+    rangeStart: currentStart,
     rangeEnd: RANDOM_MAX,
     payout: 0,
-  },
-};
+  });
 
-// 乱数から役を判定する関数
-export function getSymbolFromRandom(randomNum: number): SymbolType {
-  for (const [symbolType, config] of Object.entries(SYMBOL_CONFIGS)) {
-    if (randomNum >= config.rangeStart && randomNum <= config.rangeEnd) {
-      return symbolType as SymbolType;
-    }
-  }
-  return 'MISS';
+  return ranges;
 }
 
-// 入力値の検証用定数
-export const MIN_GAME_COUNT = 1;
-export const MAX_GAME_COUNT = 100000;
-export const DEFAULT_GAME_COUNT = 8000;
+// 乱数から役を判定する関数
+export function getSymbolFromRandom(
+  randomNum: number,
+  rangeTable: SymbolRange[]
+): SymbolRange {
+  for (const range of rangeTable) {
+    if (randomNum >= range.rangeStart && randomNum <= range.rangeEnd) {
+      return range;
+    }
+  }
+  // フォールバック（通常は到達しない）
+  return rangeTable[rangeTable.length - 1];
+}


### PR DESCRIPTION
- slotSettings.ts: 3機種（Sアイムジャグラー、マイジャグラーV、ファンキージャグラー2）の 全設定（1-6）の確率データを追加
- 確率データを1/X形式で保存し、シミュレーション時に65536の乱数範囲に動的変換
- Menu: 機種・設定をドロップダウンで選択可能に
- Graphs: 選択された機種・設定に基づいてシミュレーションを実行
- 払い出し枚数を修正（BB=251枚、RB=95枚）

https://claude.ai/code/session_01B8jzkieyAuC9FEoU9GEgg5