### PR TITLE
style: スランプグラフをデータカウンター風のデザインに変更

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,14 +8,41 @@ html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #121212;
+  color: #e0e0e0;
 }
 
 a {
-  color: inherit;
+  color: #00ff80;
   text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+a:hover {
+  color: #00cc66;
+}
+
+::selection {
+  background-color: #00ff80;
+  color: #121212;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: #1a1a1a;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #333;
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #444;
 }

--- a/components/Footer/styled.tsx
+++ b/components/Footer/styled.tsx
@@ -4,21 +4,29 @@ import styled from 'styled-components';
 
 const StyledFooter = styled.div`
   footer {
-    background-color: #333;
-    color: #fff;
-    padding: 20px 0;
+    background: linear-gradient(180deg, #171717 0%, #121212 100%);
+    border-top: 1px solid #2a2a2a;
+    color: #888;
+    padding: 24px 0;
     text-align: center;
-    font-size: 14px;
+    font-size: 13px;
+    margin-top: auto;
   }
 
   footer a {
-    color: #fff;
+    color: #aaa;
     text-decoration: none;
-    margin: 0 10px;
+    margin: 0 12px;
+    transition: color 0.2s ease;
+  }
+
+  footer a:hover {
+    color: #00ff80;
   }
 
   footer p {
-    margin-top: 10px;
+    margin-top: 16px;
+    color: #666;
   }
 
   footer ul {

--- a/components/Graphs/index.tsx
+++ b/components/Graphs/index.tsx
@@ -8,6 +8,7 @@ import {
   LinearScale,
   PointElement,
   LineElement,
+  Filler,
 } from 'chart.js';
 import StyledGraphs from './styled';
 import {
@@ -23,7 +24,7 @@ import {
   getSymbolFromRandom,
 } from '@/lib/constants/slotSettings';
 
-Chart.register(LineController, LinearScale, PointElement, LineElement);
+Chart.register(LineController, LinearScale, PointElement, LineElement, Filler);
 
 type Props = {
   game: number;
@@ -149,24 +150,72 @@ export default function Graphs({ game, machineId, setting }: Props) {
   const data = {
     datasets: [
       {
-        label: 'Slump Graph',
+        label: '差枚数',
         data: results,
-        fill: false,
-        backgroundColor: 'rgb(3, 22, 129)',
-        borderColor: 'rgba(15, 8, 227, 0.2)',
+        fill: {
+          target: 'origin',
+          above: 'rgba(0, 255, 128, 0.15)',
+          below: 'rgba(255, 80, 80, 0.15)',
+        },
+        borderColor: '#00ff80',
+        borderWidth: 2,
+        pointRadius: 0,
+        tension: 0,
       },
     ],
   };
 
   const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        display: false,
+      },
+    },
     scales: {
       x: {
         type: 'linear' as const,
         beginAtZero: true,
+        title: {
+          display: true,
+          text: '回転数',
+          color: '#aaa',
+          font: { size: 12 },
+        },
+        grid: {
+          color: 'rgba(255, 255, 255, 0.1)',
+        },
+        ticks: {
+          color: '#aaa',
+          maxTicksLimit: 10,
+        },
       },
       y: {
         type: 'linear' as const,
-        beginAtZero: true,
+        title: {
+          display: true,
+          text: '差枚数',
+          color: '#aaa',
+          font: { size: 12 },
+        },
+        grid: {
+          color: (context: { tick: { value: number } }) => {
+            if (context.tick.value === 0) {
+              return 'rgba(255, 255, 255, 0.5)';
+            }
+            return 'rgba(255, 255, 255, 0.1)';
+          },
+          lineWidth: (context: { tick: { value: number } }) => {
+            if (context.tick.value === 0) {
+              return 2;
+            }
+            return 1;
+          },
+        },
+        ticks: {
+          color: '#aaa',
+        },
       },
     },
   };

--- a/components/Graphs/styled.tsx
+++ b/components/Graphs/styled.tsx
@@ -8,33 +8,32 @@ const StyledGraphs = styled.div`
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 20px;
+    gap: 24px;
+    padding: 0 16px 40px;
   }
 
   .styled-button {
     display: inline-block;
-    font-size: 1em;
-    padding: 10px 20px;
-    margin: 10px;
-    color: #ffffff;
-    background: linear-gradient(to right, #726a95, #2c88d9);
+    font-size: 1.1em;
+    font-weight: bold;
+    padding: 14px 48px;
+    color: #121212;
+    background: linear-gradient(135deg, #00ff80 0%, #00cc66 100%);
     border: none;
-    border-radius: 5px;
-    text-decoration: none;
-    transition: all 0.3s ease-out;
+    border-radius: 6px;
     cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 15px rgba(0, 255, 128, 0.3);
   }
 
   .styled-button:hover {
-    background: linear-gradient(to right, #2c88d9, #726a95);
-    box-shadow: 0 12px 16px 0 rgba(0, 0, 0, 0.24),
-      0 17px 50px 0 rgba(0, 0, 0, 0.19);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(0, 255, 128, 0.4);
   }
 
   .styled-button:active {
-    background: #2c88d9;
-    box-shadow: 0 5px #666;
-    transform: translateY(4px);
+    transform: translateY(0);
+    box-shadow: 0 2px 10px rgba(0, 255, 128, 0.3);
   }
 
   .graph {
@@ -48,40 +47,76 @@ const StyledGraphs = styled.div`
   }
 
   .styled-table {
-    font-family: Arial, sans-serif;
     border-collapse: collapse;
-    width: 60%;
-    margin: auto;
-    box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.15);
-    color: #333;
+    width: 90%;
+    max-width: 500px;
+    background-color: #1a1a1a;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
   }
 
   .styled-table caption {
-    font-size: 1.5em;
-    margin-bottom: 10px;
+    padding: 14px 16px;
+    font-size: 1.1em;
+    font-weight: bold;
+    color: #00ff80;
+    background-color: #222;
     text-align: left;
+    border-bottom: 1px solid #333;
   }
 
   .styled-table th {
-    width: 20%;
-    background-color: #333;
-    color: white;
-    padding: 10px;
+    padding: 10px 16px;
+    background-color: #252525;
+    color: #aaa;
+    font-weight: normal;
     text-align: left;
+    width: 40%;
+    border-bottom: 1px solid #333;
   }
 
   .styled-table td {
-    border: 1px solid #999;
-    padding: 10px;
-    text-align: center;
+    padding: 10px 16px;
+    text-align: right;
+    color: #e0e0e0;
+    border-bottom: 1px solid #333;
   }
 
-  .styled-table tr:nth-child(even) {
-    background-color: #f2f2f2;
+  .styled-table thead th,
+  .styled-table thead td {
+    background-color: #222;
+    color: #888;
+    font-size: 0.85em;
+    padding: 8px 16px;
   }
 
-  .styled-table:last-of-type {
-    margin-bottom: 30px;
+  .styled-table tbody tr:last-child th,
+  .styled-table tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  .styled-table tbody tr:hover {
+    background-color: rgba(0, 255, 128, 0.05);
+  }
+
+  .error-message {
+    color: #ff6b6b !important;
+    background-color: rgba(255, 107, 107, 0.1);
+    padding: 12px 20px;
+    border-radius: 6px;
+    border: 1px solid rgba(255, 107, 107, 0.3);
+  }
+
+  @media screen and (max-width: 600px) {
+    .graph {
+      width: 95%;
+      height: 300px;
+      padding: 12px;
+    }
+    .styled-table {
+      width: 95%;
+    }
   }
 `;
 

--- a/components/Graphs/styled.tsx
+++ b/components/Graphs/styled.tsx
@@ -38,7 +38,13 @@ const StyledGraphs = styled.div`
   }
 
   .graph {
-    width: 80%;
+    width: 90%;
+    max-width: 800px;
+    height: 400px;
+    background-color: #1a1a1a;
+    border-radius: 8px;
+    padding: 20px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
   }
 
   .styled-table {

--- a/components/Header/styled.tsx
+++ b/components/Header/styled.tsx
@@ -7,45 +7,52 @@ const StyledHeader = styled.div`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: 20px;
-    background-color: #333;
-    color: #fff;
+    padding: 16px 24px;
+    background: linear-gradient(180deg, #1f1f1f 0%, #171717 100%);
+    border-bottom: 1px solid #2a2a2a;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
   }
 
   .title h1 {
     margin: 0;
     font-size: 1.5em;
     font-weight: bold;
+    color: #00ff80;
+    text-shadow: 0 0 10px rgba(0, 255, 128, 0.3);
   }
 
   .title p {
-    margin: 0;
-    font-size: 0.9em;
-    color: #ddd;
+    margin: 4px 0 0 0;
+    font-size: 0.8em;
+    color: #888;
   }
 
   .menu ul {
     display: flex;
     list-style: none;
     padding: 0;
-  }
-
-  .menu ul li {
-    margin-left: 20px;
+    gap: 8px;
   }
 
   .menu ul li a {
+    display: block;
+    padding: 8px 16px;
     text-decoration: none;
-    color: #fff;
+    color: #aaa;
     font-size: 0.9em;
-    transition: color 0.3s ease;
+    border-radius: 4px;
+    transition: all 0.2s ease;
   }
 
   .menu ul li a:hover {
-    color: #ddd;
+    color: #00ff80;
+    background-color: rgba(0, 255, 128, 0.1);
   }
 
   @media screen and (max-width: 768px) {
+    header {
+      padding: 12px 16px;
+    }
     header .title p,
     .menu {
       display: none;

--- a/components/Menu/styled.tsx
+++ b/components/Menu/styled.tsx
@@ -6,37 +6,98 @@ const StyledMenu = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 30vh;
+  padding: 32px 16px;
 
   .styled-table {
     border-collapse: collapse;
-    margin: 25px 0;
-    font-size: 0.9em;
-    font-family: sans-serif;
-    min-width: 400px;
-    box-shadow: 0 0 20px rgba(0, 0, 0, 0.15);
+    font-size: 0.95em;
+    min-width: 320px;
+    background-color: #1a1a1a;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
   }
-  .styled-table thead tr {
-    background-color: #009879;
-    color: #ffffff;
-    text-align: left;
-  }
-  .styled-table th,
-  .styled-table td {
-    padding: 12px 15px;
-  }
-  .styled-table tbody tr {
-    border-bottom: 1px solid #dddddd;
-  }
-  .styled-table tbody tr:nth-of-type(even) {
-    background-color: #f3f3f3;
-  }
-  .styled-table tbody tr:last-of-type {
-    border-bottom: 2px solid #009879;
-  }
-  .styled-table tbody tr.active-row {
+
+  .styled-table caption {
+    padding: 16px;
+    font-size: 1.1em;
     font-weight: bold;
-    color: #009879;
+    color: #00ff80;
+    background-color: #222;
+    text-align: left;
+    border-bottom: 1px solid #333;
+  }
+
+  .styled-table th {
+    padding: 12px 16px;
+    background-color: #252525;
+    color: #aaa;
+    font-weight: normal;
+    text-align: left;
+    width: 120px;
+    border-bottom: 1px solid #333;
+  }
+
+  .styled-table td {
+    padding: 12px 16px;
+    border-bottom: 1px solid #333;
+  }
+
+  .styled-table tbody tr:last-child th,
+  .styled-table tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  .styled-table select,
+  .styled-table input {
+    width: 100%;
+    padding: 10px 12px;
+    font-size: 1em;
+    background-color: #2a2a2a;
+    border: 1px solid #444;
+    border-radius: 4px;
+    color: #fff;
+    outline: none;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .styled-table select:focus,
+  .styled-table input:focus {
+    border-color: #00ff80;
+    box-shadow: 0 0 0 2px rgba(0, 255, 128, 0.2);
+  }
+
+  .styled-table select {
+    cursor: pointer;
+    appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23888' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    padding-right: 36px;
+  }
+
+  .styled-table select option {
+    background-color: #2a2a2a;
+    color: #fff;
+  }
+
+  .styled-table input[type='number'] {
+    -moz-appearance: textfield;
+  }
+
+  .styled-table input[type='number']::-webkit-outer-spin-button,
+  .styled-table input[type='number']::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  @media screen and (max-width: 480px) {
+    .styled-table {
+      min-width: 280px;
+    }
+    .styled-table th {
+      width: 100px;
+    }
   }
 `;
 


### PR DESCRIPTION
- 黒背景でグラフを表示
- グリーンのライン（プラス領域は緑、マイナス領域は赤の薄い塗りつぶし）
- 0ラインを強調表示
- グリッド線を暗めに調整
- 回転数・差枚数のラベルを追加
- ポイントを非表示にしてスムーズな線に

https://claude.ai/code/session_01B8jzkieyAuC9FEoU9GEgg5