### PR TITLE
feat: 複数回シミュレーション機能を追加

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,7 @@ export default function Home() {
   const [game, setGame] = useState<number>(8000);
   const [machineId, setMachineId] = useState<MachineId>('aim');
   const [setting, setSetting] = useState<SettingLevel>(6);
+  const [trialCount, setTrialCount] = useState<number>(100);
 
   return (
     <>
@@ -22,8 +23,10 @@ export default function Home() {
         setMachineId={setMachineId}
         setting={setting}
         setSetting={setSetting}
+        trialCount={trialCount}
+        setTrialCount={setTrialCount}
       />
-      <Graphs game={game} machineId={machineId} setting={setting} />
+      <Graphs game={game} machineId={machineId} setting={setting} trialCount={trialCount} />
       <Footer />
     </>
   );

--- a/components/Graphs/index.tsx
+++ b/components/Graphs/index.tsx
@@ -511,27 +511,29 @@ export default function Graphs({ game, machineId, setting, trialCount }: Props) 
           </table>
         )}
 
-        <table className="styled-table">
-          <caption>{isMultiMode ? '最終試行の結果' : '結果'}</caption>
-          <tbody>
-            <tr>
-              <th>差枚数</th>
-              <td>{totalCoins}枚</td>
-            </tr>
-            <tr>
-              <th>収支</th>
-              <td>{totalCoins * YEN_PER_COIN}円</td>
-            </tr>
-            <tr>
-              <th>機械割</th>
-              <td>{calculatePayoutRate()}%</td>
-            </tr>
-            <tr>
-              <th>最大ハマり</th>
-              <td>{maxHamari}G</td>
-            </tr>
-          </tbody>
-        </table>
+        {!isMultiMode && (
+          <table className="styled-table">
+            <caption>結果</caption>
+            <tbody>
+              <tr>
+                <th>差枚数</th>
+                <td>{totalCoins}枚</td>
+              </tr>
+              <tr>
+                <th>収支</th>
+                <td>{totalCoins * YEN_PER_COIN}円</td>
+              </tr>
+              <tr>
+                <th>機械割</th>
+                <td>{calculatePayoutRate()}%</td>
+              </tr>
+              <tr>
+                <th>最大ハマり</th>
+                <td>{maxHamari}G</td>
+              </tr>
+            </tbody>
+          </table>
+        )}
 
         {!isMultiMode && (
           <table className="styled-table">

--- a/components/Graphs/index.tsx
+++ b/components/Graphs/index.tsx
@@ -58,6 +58,7 @@ interface MultiSimulationStats {
 export default function Graphs({ game, machineId, setting, trialCount }: Props) {
   const [totalCoins, setTotalCoins] = useState(0);
   const [results, setResults] = useState<{ x: number; y: number }[]>([]);
+  const [multiResults, setMultiResults] = useState<{ x: number; y: number }[][]>([]);
   const [bbCount, setBBCount] = useState(0);
   const [rbCount, setRBCount] = useState(0);
   const [cherryCount, setCherryCount] = useState(0);
@@ -194,6 +195,7 @@ export default function Graphs({ game, machineId, setting, trialCount }: Props) 
     setError(null);
     setIsMultiMode(false);
     setMultiStats(null);
+    setMultiResults([]);
 
     let bb = 0,
       rb = 0,
@@ -308,7 +310,10 @@ export default function Graphs({ game, machineId, setting, trialCount }: Props) 
 
     setMultiStats(stats);
 
-    // 最後のシミュレーション結果をグラフに表示
+    // すべてのシミュレーション結果をグラフ用に保存
+    setMultiResults(results.map((r) => r.graphData));
+
+    // 最後のシミュレーション結果を詳細表示用に設定
     const lastResult = results[results.length - 1];
     setResults(lastResult.graphData);
     setTotalCoins(lastResult.totalCoins);
@@ -317,30 +322,62 @@ export default function Graphs({ game, machineId, setting, trialCount }: Props) 
     setMaxHamari(lastResult.maxHamari);
   };
 
-  const data = {
-    datasets: [
-      {
-        label: '差枚数',
-        data: results,
-        fill: {
-          target: 'origin',
-          above: 'rgba(0, 255, 128, 0.15)',
-          below: 'rgba(255, 80, 80, 0.15)',
+  // 複数回シミュレーション用のデータセット生成
+  const generateMultiDatasets = () => {
+    if (!isMultiMode || multiResults.length === 0) {
+      return [
+        {
+          label: '差枚数',
+          data: results,
+          fill: {
+            target: 'origin',
+            above: 'rgba(0, 255, 128, 0.15)',
+            below: 'rgba(255, 80, 80, 0.15)',
+          },
+          borderColor: '#00ff80',
+          borderWidth: 2,
+          pointRadius: 0,
+          tension: 0,
         },
-        borderColor: '#00ff80',
-        borderWidth: 2,
+      ];
+    }
+
+    // 各ラインの最終結果に基づいて色を決定
+    return multiResults.map((graphData, index) => {
+      const finalValue = graphData[graphData.length - 1]?.y || 0;
+      const isPositive = finalValue >= 0;
+      // 透明度を調整（試行回数が多いほど薄く）
+      const opacity = Math.max(0.1, Math.min(0.6, 30 / trialCount));
+      const color = isPositive
+        ? `rgba(0, 255, 128, ${opacity})`
+        : `rgba(255, 80, 80, ${opacity})`;
+
+      return {
+        label: `試行${index + 1}`,
+        data: graphData,
+        fill: false,
+        borderColor: color,
+        borderWidth: 1,
         pointRadius: 0,
         tension: 0,
-      },
-    ],
+      };
+    });
+  };
+
+  const data = {
+    datasets: generateMultiDatasets(),
   };
 
   const options = {
     responsive: true,
     maintainAspectRatio: false,
+    animation: isMultiMode ? { duration: 0 } : { duration: 750 },
     plugins: {
       legend: {
         display: false,
+      },
+      tooltip: {
+        enabled: !isMultiMode || multiResults.length <= 10,
       },
     },
     scales: {

--- a/components/Graphs/index.tsx
+++ b/components/Graphs/index.tsx
@@ -30,9 +30,32 @@ type Props = {
   game: number;
   machineId: MachineId;
   setting: SettingLevel;
+  trialCount: number;
 };
 
-export default function Graphs({ game, machineId, setting }: Props) {
+// 1回のシミュレーション結果
+interface SingleSimulationResult {
+  totalCoins: number;
+  bbCount: number;
+  rbCount: number;
+  maxHamari: number;
+  graphData: { x: number; y: number }[];
+}
+
+// 複数回シミュレーションの統計結果
+interface MultiSimulationStats {
+  maxProfit: number;
+  minProfit: number;
+  avgProfit: number;
+  maxBonusCount: number;
+  minBonusCount: number;
+  avgBonusCount: number;
+  winRate: number;
+  avgPayoutRate: number;
+  maxHamari: number;
+}
+
+export default function Graphs({ game, machineId, setting, trialCount }: Props) {
   const [totalCoins, setTotalCoins] = useState(0);
   const [results, setResults] = useState<{ x: number; y: number }[]>([]);
   const [bbCount, setBBCount] = useState(0);
@@ -43,6 +66,8 @@ export default function Graphs({ game, machineId, setting }: Props) {
   const [missCount, setMissCount] = useState(0);
   const [maxHamari, setMaxHamari] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  const [multiStats, setMultiStats] = useState<MultiSimulationStats | null>(null);
+  const [isMultiMode, setIsMultiMode] = useState(false);
 
   const rangeTable = useMemo(
     () => generateRangeTable(machineId, setting),
@@ -89,6 +114,76 @@ export default function Graphs({ game, machineId, setting }: Props) {
     return null;
   };
 
+  // 1回のシミュレーションを実行
+  const runSingleSimulation = (): SingleSimulationResult => {
+    let bb = 0,
+      rb = 0,
+      cherry = 0,
+      replay = 0,
+      grape = 0,
+      miss = 0;
+    let newCoins = 0;
+    let currentHamari = 0;
+    let maxHamariCount = 0;
+    const newResults: { x: number; y: number }[] = [{ x: 0, y: 0 }];
+
+    for (let i = 0; i < game; i++) {
+      newCoins -= COINS_PER_GAME;
+      const randomNum = Math.floor(Math.random() * RANDOM_MAX + 1);
+      const result = getSymbolFromRandom(randomNum, rangeTable);
+
+      newCoins += result.payout;
+
+      switch (result.symbol) {
+        case 'BB':
+          bb++;
+          if (currentHamari > maxHamariCount) {
+            maxHamariCount = currentHamari;
+          }
+          currentHamari = 0;
+          break;
+        case 'RB':
+          rb++;
+          if (currentHamari > maxHamariCount) {
+            maxHamariCount = currentHamari;
+          }
+          currentHamari = 0;
+          break;
+        case 'CHERRY':
+          cherry++;
+          currentHamari++;
+          break;
+        case 'REPLAY':
+          replay++;
+          currentHamari++;
+          break;
+        case 'GRAPE':
+          grape++;
+          currentHamari++;
+          break;
+        case 'MISS':
+        default:
+          miss++;
+          currentHamari++;
+          break;
+      }
+      newResults.push({ x: i + 1, y: newCoins });
+    }
+
+    if (currentHamari > maxHamariCount) {
+      maxHamariCount = currentHamari;
+    }
+
+    return {
+      totalCoins: newCoins,
+      bbCount: bb,
+      rbCount: rb,
+      maxHamari: maxHamariCount,
+      graphData: newResults,
+    };
+  };
+
+  // 単発シミュレーション
   const runSimulation = () => {
     const validationError = validateGameCount(game);
     if (validationError) {
@@ -97,6 +192,8 @@ export default function Graphs({ game, machineId, setting }: Props) {
     }
 
     setError(null);
+    setIsMultiMode(false);
+    setMultiStats(null);
 
     let bb = 0,
       rb = 0,
@@ -152,7 +249,6 @@ export default function Graphs({ game, machineId, setting }: Props) {
       newResults.push({ x: i + 1, y: newCoins });
     }
 
-    // 最後のハマりもチェック
     if (currentHamari > maxHamariCount) {
       maxHamariCount = currentHamari;
     }
@@ -166,6 +262,59 @@ export default function Graphs({ game, machineId, setting }: Props) {
     setMissCount(miss);
     setMaxHamari(maxHamariCount);
     setTotalCoins(newCoins);
+  };
+
+  // 複数回シミュレーション
+  const runMultiSimulation = () => {
+    const validationError = validateGameCount(game);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setError(null);
+    setIsMultiMode(true);
+
+    const results: SingleSimulationResult[] = [];
+    const totalBet = game * COINS_PER_GAME;
+
+    for (let i = 0; i < trialCount; i++) {
+      results.push(runSingleSimulation());
+    }
+
+    // 統計を計算
+    const profits = results.map((r) => r.totalCoins);
+    const bonusCounts = results.map((r) => r.bbCount + r.rbCount);
+    const hamaris = results.map((r) => r.maxHamari);
+    const payoutRates = results.map(
+      (r) => ((r.totalCoins + totalBet) / totalBet) * 100
+    );
+
+    const stats: MultiSimulationStats = {
+      maxProfit: Math.max(...profits),
+      minProfit: Math.min(...profits),
+      avgProfit: Math.round(profits.reduce((a, b) => a + b, 0) / trialCount),
+      maxBonusCount: Math.max(...bonusCounts),
+      minBonusCount: Math.min(...bonusCounts),
+      avgBonusCount: Math.round(
+        (bonusCounts.reduce((a, b) => a + b, 0) / trialCount) * 10
+      ) / 10,
+      winRate: Math.round((profits.filter((p) => p > 0).length / trialCount) * 1000) / 10,
+      avgPayoutRate: Math.round(
+        (payoutRates.reduce((a, b) => a + b, 0) / trialCount) * 100
+      ) / 100,
+      maxHamari: Math.max(...hamaris),
+    };
+
+    setMultiStats(stats);
+
+    // 最後のシミュレーション結果をグラフに表示
+    const lastResult = results[results.length - 1];
+    setResults(lastResult.graphData);
+    setTotalCoins(lastResult.totalCoins);
+    setBBCount(lastResult.bbCount);
+    setRBCount(lastResult.rbCount);
+    setMaxHamari(lastResult.maxHamari);
   };
 
   const data = {
@@ -256,22 +405,77 @@ export default function Graphs({ game, machineId, setting }: Props) {
     <StyledGraphs>
       <div className="container">
         {error && (
-          <div
-            className="error-message"
-            style={{ color: 'red', marginBottom: '10px' }}
-          >
+          <div className="error-message">
             {error}
           </div>
         )}
-        <button className="styled-button" onClick={runSimulation}>
-          スタート
-        </button>
+        <div className="button-group">
+          <button className="styled-button" onClick={runSimulation}>
+            単発シミュレーション
+          </button>
+          <button className="styled-button multi" onClick={runMultiSimulation}>
+            {trialCount}回シミュレーション
+          </button>
+        </div>
         <div className="graph">
           <Line data={data} options={options} />
         </div>
 
+        {isMultiMode && multiStats && (
+          <table className="styled-table stats-table">
+            <caption>統計結果（{trialCount}回試行）</caption>
+            <tbody>
+              <tr>
+                <th>最大収支</th>
+                <td className={multiStats.maxProfit >= 0 ? 'positive' : 'negative'}>
+                  {multiStats.maxProfit >= 0 ? '+' : ''}{multiStats.maxProfit}枚
+                  （{multiStats.maxProfit >= 0 ? '+' : ''}{multiStats.maxProfit * YEN_PER_COIN}円）
+                </td>
+              </tr>
+              <tr>
+                <th>最低収支</th>
+                <td className={multiStats.minProfit >= 0 ? 'positive' : 'negative'}>
+                  {multiStats.minProfit >= 0 ? '+' : ''}{multiStats.minProfit}枚
+                  （{multiStats.minProfit >= 0 ? '+' : ''}{multiStats.minProfit * YEN_PER_COIN}円）
+                </td>
+              </tr>
+              <tr>
+                <th>平均収支</th>
+                <td className={multiStats.avgProfit >= 0 ? 'positive' : 'negative'}>
+                  {multiStats.avgProfit >= 0 ? '+' : ''}{multiStats.avgProfit}枚
+                  （{multiStats.avgProfit >= 0 ? '+' : ''}{multiStats.avgProfit * YEN_PER_COIN}円）
+                </td>
+              </tr>
+              <tr>
+                <th>勝率</th>
+                <td>{multiStats.winRate}%</td>
+              </tr>
+              <tr>
+                <th>平均機械割</th>
+                <td>{multiStats.avgPayoutRate}%</td>
+              </tr>
+              <tr>
+                <th>最大ボーナス回数</th>
+                <td>{multiStats.maxBonusCount}回</td>
+              </tr>
+              <tr>
+                <th>最小ボーナス回数</th>
+                <td>{multiStats.minBonusCount}回</td>
+              </tr>
+              <tr>
+                <th>平均ボーナス回数</th>
+                <td>{multiStats.avgBonusCount}回</td>
+              </tr>
+              <tr>
+                <th>最大ハマり</th>
+                <td>{multiStats.maxHamari}G</td>
+              </tr>
+            </tbody>
+          </table>
+        )}
+
         <table className="styled-table">
-          <caption>結果</caption>
+          <caption>{isMultiMode ? '最終試行の結果' : '結果'}</caption>
           <tbody>
             <tr>
               <th>差枚数</th>
@@ -292,53 +496,55 @@ export default function Graphs({ game, machineId, setting }: Props) {
           </tbody>
         </table>
 
-        <table className="styled-table">
-          <caption>ボーナス・小役</caption>
-          <thead>
-            <tr>
-              <th></th>
-              <td>回数</td>
-              <td>確率</td>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th>{SYMBOL_DISPLAY_NAMES.BB}</th>
-              <td>{bbCount}</td>
-              <td>{fraction(bbCount, totalCount)}</td>
-            </tr>
-            <tr>
-              <th>{SYMBOL_DISPLAY_NAMES.RB}</th>
-              <td>{rbCount}</td>
-              <td>{fraction(rbCount, totalCount)}</td>
-            </tr>
-            <tr>
-              <th>合算</th>
-              <td>{rbCount + bbCount}</td>
-              <td>{fraction(rbCount + bbCount, totalCount)}</td>
-            </tr>
-            <tr>
-              <th>{SYMBOL_DISPLAY_NAMES.CHERRY}</th>
-              <td>{cherryCount}</td>
-              <td>{fraction(cherryCount, totalCount)}</td>
-            </tr>
-            <tr>
-              <th>{SYMBOL_DISPLAY_NAMES.REPLAY}</th>
-              <td>{replayCount}</td>
-              <td>{fraction(replayCount, totalCount)}</td>
-            </tr>
-            <tr>
-              <th>{SYMBOL_DISPLAY_NAMES.GRAPE}</th>
-              <td>{grapeCount}</td>
-              <td>{fraction(grapeCount, totalCount)}</td>
-            </tr>
-            <tr>
-              <th>{SYMBOL_DISPLAY_NAMES.MISS}</th>
-              <td>{missCount}</td>
-              <td>{fraction(missCount, totalCount)}</td>
-            </tr>
-          </tbody>
-        </table>
+        {!isMultiMode && (
+          <table className="styled-table">
+            <caption>ボーナス・小役</caption>
+            <thead>
+              <tr>
+                <th></th>
+                <td>回数</td>
+                <td>確率</td>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th>{SYMBOL_DISPLAY_NAMES.BB}</th>
+                <td>{bbCount}</td>
+                <td>{fraction(bbCount, totalCount)}</td>
+              </tr>
+              <tr>
+                <th>{SYMBOL_DISPLAY_NAMES.RB}</th>
+                <td>{rbCount}</td>
+                <td>{fraction(rbCount, totalCount)}</td>
+              </tr>
+              <tr>
+                <th>合算</th>
+                <td>{rbCount + bbCount}</td>
+                <td>{fraction(rbCount + bbCount, totalCount)}</td>
+              </tr>
+              <tr>
+                <th>{SYMBOL_DISPLAY_NAMES.CHERRY}</th>
+                <td>{cherryCount}</td>
+                <td>{fraction(cherryCount, totalCount)}</td>
+              </tr>
+              <tr>
+                <th>{SYMBOL_DISPLAY_NAMES.REPLAY}</th>
+                <td>{replayCount}</td>
+                <td>{fraction(replayCount, totalCount)}</td>
+              </tr>
+              <tr>
+                <th>{SYMBOL_DISPLAY_NAMES.GRAPE}</th>
+                <td>{grapeCount}</td>
+                <td>{fraction(grapeCount, totalCount)}</td>
+              </tr>
+              <tr>
+                <th>{SYMBOL_DISPLAY_NAMES.MISS}</th>
+                <td>{missCount}</td>
+                <td>{fraction(missCount, totalCount)}</td>
+              </tr>
+            </tbody>
+          </table>
+        )}
       </div>
     </StyledGraphs>
   );

--- a/components/Graphs/styled.tsx
+++ b/components/Graphs/styled.tsx
@@ -12,11 +12,18 @@ const StyledGraphs = styled.div`
     padding: 0 16px 40px;
   }
 
+  .button-group {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
   .styled-button {
     display: inline-block;
     font-size: 1.1em;
     font-weight: bold;
-    padding: 14px 48px;
+    padding: 14px 32px;
     color: #121212;
     background: linear-gradient(135deg, #00ff80 0%, #00cc66 100%);
     border: none;
@@ -34,6 +41,19 @@ const StyledGraphs = styled.div`
   .styled-button:active {
     transform: translateY(0);
     box-shadow: 0 2px 10px rgba(0, 255, 128, 0.3);
+  }
+
+  .styled-button.multi {
+    background: linear-gradient(135deg, #80d4ff 0%, #4db8ff 100%);
+    box-shadow: 0 4px 15px rgba(77, 184, 255, 0.3);
+  }
+
+  .styled-button.multi:hover {
+    box-shadow: 0 6px 20px rgba(77, 184, 255, 0.4);
+  }
+
+  .styled-button.multi:active {
+    box-shadow: 0 2px 10px rgba(77, 184, 255, 0.3);
   }
 
   .graph {
@@ -98,6 +118,22 @@ const StyledGraphs = styled.div`
 
   .styled-table tbody tr:hover {
     background-color: rgba(0, 255, 128, 0.05);
+  }
+
+  .stats-table {
+    border: 2px solid #4db8ff;
+  }
+
+  .stats-table caption {
+    color: #80d4ff;
+  }
+
+  .positive {
+    color: #00ff80 !important;
+  }
+
+  .negative {
+    color: #ff6b6b !important;
   }
 
   .error-message {

--- a/components/Menu/index.tsx
+++ b/components/Menu/index.tsx
@@ -14,6 +14,8 @@ type Props = {
   setMachineId: (value: MachineId) => void;
   setting: SettingLevel;
   setSetting: (value: SettingLevel) => void;
+  trialCount: number;
+  setTrialCount: (value: number) => void;
 };
 
 export default function Menu({
@@ -23,6 +25,8 @@ export default function Menu({
   setMachineId,
   setting,
   setSetting,
+  trialCount,
+  setTrialCount,
 }: Props) {
   const handleGameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
@@ -42,6 +46,18 @@ export default function Menu({
 
   const handleSettingChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSetting(Number(e.target.value) as SettingLevel);
+  };
+
+  const handleTrialCountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value === '') {
+      setTrialCount(1);
+    } else {
+      const numValue = parseInt(value, 10);
+      if (!isNaN(numValue) && numValue >= 1 && numValue <= 1000) {
+        setTrialCount(numValue);
+      }
+    }
   };
 
   return (
@@ -91,6 +107,19 @@ export default function Menu({
                 onChange={handleGameChange}
                 min={1}
                 max={100000}
+              />
+            </td>
+          </tr>
+          <tr>
+            <th>試行回数</th>
+            <td>
+              <input
+                type="number"
+                id="trial-count"
+                value={trialCount}
+                onChange={handleTrialCountChange}
+                min={1}
+                max={1000}
               />
             </td>
           </tr>


### PR DESCRIPTION
- 最大1000回まで同一条件でシミュレーションを繰り返し実行可能
- 統計結果の表示（最大/最低/平均収支、勝率、平均機械割、ボーナス回数、最大ハマり）
- 単発/複数回シミュレーションを切り替えるボタンUI
- 試行回数入力フィールドを条件設定に追加

https://claude.ai/code/session_01B8jzkieyAuC9FEoU9GEgg5