### PR TITLE
feat: 設定推測ツールを追加

### DIFF
--- a/app/estimate/page.tsx
+++ b/app/estimate/page.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useState } from 'react';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+import SettingEstimator from '@/components/SettingEstimator';
+import { MachineId } from '@/lib/constants/slotSettings';
+
+export default function EstimatePage() {
+  const [machineId, setMachineId] = useState<MachineId>('aim');
+
+  return (
+    <>
+      <Header />
+      <main>
+        <SettingEstimator machineId={machineId} setMachineId={setMachineId} />
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/components/Header/index.tsx
+++ b/components/Header/index.tsx
@@ -14,13 +14,13 @@ export default function Header() {
         <div className="menu">
           <ul>
             <li>
-              <Link href="/">HOME</Link>
+              <Link href="/">シミュレーター</Link>
+            </li>
+            <li>
+              <Link href="/estimate">設定推測</Link>
             </li>
             <li>
               <Link href="/about">開発者について</Link>
-            </li>
-            <li>
-              <Link href="/detail">詳細</Link>
             </li>
             <li>
               <Link href="/contact">お問合せ</Link>

--- a/components/SettingEstimator/index.tsx
+++ b/components/SettingEstimator/index.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import StyledEstimator from './styled';
+import {
+  MachineId,
+  SettingLevel,
+  MACHINES,
+  MACHINE_LIST,
+} from '@/lib/constants/slotSettings';
+
+type Props = {
+  machineId: MachineId;
+  setMachineId: (value: MachineId) => void;
+};
+
+interface EstimationResult {
+  setting: SettingLevel;
+  probability: number;
+  rank: number;
+}
+
+export default function SettingEstimator({ machineId, setMachineId }: Props) {
+  const [gameCount, setGameCount] = useState<number>(8000);
+  const [bbCount, setBbCount] = useState<number>(30);
+  const [rbCount, setRbCount] = useState<number>(25);
+  const [grapeCount, setGrapeCount] = useState<number>(1300);
+  const [results, setResults] = useState<EstimationResult[] | null>(null);
+
+  const machine = useMemo(() => MACHINES[machineId], [machineId]);
+
+  // ポアソン分布の確率質量関数（対数版）
+  const logPoisson = (k: number, lambda: number): number => {
+    if (lambda <= 0) return -Infinity;
+    if (k < 0) return -Infinity;
+    // log(P(X=k)) = k*log(lambda) - lambda - log(k!)
+    let logFactorial = 0;
+    for (let i = 2; i <= k; i++) {
+      logFactorial += Math.log(i);
+    }
+    return k * Math.log(lambda) - lambda - logFactorial;
+  };
+
+  // 設定推測を実行
+  const runEstimation = () => {
+    if (gameCount <= 0) return;
+
+    const settings: SettingLevel[] = [1, 2, 3, 4, 5, 6];
+    const logLikelihoods: number[] = [];
+
+    for (const setting of settings) {
+      const prob = machine.settings[setting];
+
+      // 各設定での期待値を計算
+      const expectedBB = gameCount / (1 / (1 / prob.singleBB + 1 / prob.cherryBB));
+      const expectedRB = gameCount / (1 / (1 / prob.singleRB + 1 / prob.cherryRB));
+      const expectedGrape = gameCount / prob.grape;
+
+      // 対数尤度を計算（ポアソン分布を使用）
+      const logLikelihood =
+        logPoisson(bbCount, expectedBB) +
+        logPoisson(rbCount, expectedRB) +
+        logPoisson(grapeCount, expectedGrape);
+
+      logLikelihoods.push(logLikelihood);
+    }
+
+    // 最大対数尤度を引いて数値的安定性を確保
+    const maxLogLikelihood = Math.max(...logLikelihoods);
+    const likelihoods = logLikelihoods.map((ll) =>
+      Math.exp(ll - maxLogLikelihood)
+    );
+
+    // 事前確率は均等（1/6）として正規化
+    const totalLikelihood = likelihoods.reduce((a, b) => a + b, 0);
+    const posteriors = likelihoods.map((l) => (l / totalLikelihood) * 100);
+
+    // 結果を作成してランク付け
+    const estimationResults: EstimationResult[] = settings.map(
+      (setting, index) => ({
+        setting,
+        probability: Math.round(posteriors[index] * 10) / 10,
+        rank: 0,
+      })
+    );
+
+    // 確率順にソートしてランク付け
+    const sorted = [...estimationResults].sort(
+      (a, b) => b.probability - a.probability
+    );
+    sorted.forEach((result, index) => {
+      result.rank = index + 1;
+    });
+
+    setResults(estimationResults);
+  };
+
+  const handleNumberInput = (
+    value: string,
+    setter: (v: number) => void
+  ) => {
+    const num = parseInt(value, 10);
+    if (value === '' || isNaN(num)) {
+      setter(0);
+    } else {
+      setter(num);
+    }
+  };
+
+  // 合算確率の表示
+  const getCombinedProbability = (setting: SettingLevel) => {
+    const prob = machine.settings[setting];
+    const bbProb = 1 / (1 / prob.singleBB + 1 / prob.cherryBB);
+    const rbProb = 1 / (1 / prob.singleRB + 1 / prob.cherryRB);
+    const combined = 1 / (1 / bbProb + 1 / rbProb);
+    return combined.toFixed(1);
+  };
+
+  const getGrapeProbability = (setting: SettingLevel) => {
+    return machine.settings[setting].grape.toFixed(2);
+  };
+
+  return (
+    <StyledEstimator>
+      <div className="container">
+        <h1>設定推測ツール</h1>
+        <p className="description">
+          実際のプレイデータを入力して、設定を推測します。
+        </p>
+
+        <div className="input-section">
+          <div className="input-group">
+            <label htmlFor="machine">機種</label>
+            <select
+              id="machine"
+              value={machineId}
+              onChange={(e) => setMachineId(e.target.value as MachineId)}
+            >
+              {MACHINE_LIST.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="input-group">
+            <label htmlFor="gameCount">回転数</label>
+            <input
+              id="gameCount"
+              type="number"
+              value={gameCount || ''}
+              onChange={(e) => handleNumberInput(e.target.value, setGameCount)}
+              min={1}
+            />
+          </div>
+
+          <div className="input-group">
+            <label htmlFor="bbCount">BB回数</label>
+            <input
+              id="bbCount"
+              type="number"
+              value={bbCount || ''}
+              onChange={(e) => handleNumberInput(e.target.value, setBbCount)}
+              min={0}
+            />
+          </div>
+
+          <div className="input-group">
+            <label htmlFor="rbCount">RB回数</label>
+            <input
+              id="rbCount"
+              type="number"
+              value={rbCount || ''}
+              onChange={(e) => handleNumberInput(e.target.value, setRbCount)}
+              min={0}
+            />
+          </div>
+
+          <div className="input-group">
+            <label htmlFor="grapeCount">ぶどう回数</label>
+            <input
+              id="grapeCount"
+              type="number"
+              value={grapeCount || ''}
+              onChange={(e) => handleNumberInput(e.target.value, setGrapeCount)}
+              min={0}
+            />
+          </div>
+
+          <button className="estimate-button" onClick={runEstimation}>
+            設定推測
+          </button>
+        </div>
+
+        {results && (
+          <div className="results-section">
+            <table className="results-table">
+              <caption>推測結果</caption>
+              <thead>
+                <tr>
+                  <th>設定</th>
+                  <th>確率</th>
+                  <th>合算</th>
+                  <th>ぶどう</th>
+                </tr>
+              </thead>
+              <tbody>
+                {results.map((result) => (
+                  <tr
+                    key={result.setting}
+                    className={
+                      result.rank === 1
+                        ? 'rank-1'
+                        : result.rank === 2
+                        ? 'rank-2'
+                        : ''
+                    }
+                  >
+                    <td className="setting-cell">設定{result.setting}</td>
+                    <td className="probability-cell">
+                      <div className="probability-bar-container">
+                        <div
+                          className="probability-bar"
+                          style={{ width: `${result.probability}%` }}
+                        />
+                        <span className="probability-value">
+                          {result.probability}%
+                        </span>
+                      </div>
+                    </td>
+                    <td>1/{getCombinedProbability(result.setting)}</td>
+                    <td>1/{getGrapeProbability(result.setting)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+
+            <div className="actual-data">
+              <h3>入力データの確率</h3>
+              <table className="data-table">
+                <tbody>
+                  <tr>
+                    <th>BB確率</th>
+                    <td>1/{(gameCount / bbCount).toFixed(1)}</td>
+                  </tr>
+                  <tr>
+                    <th>RB確率</th>
+                    <td>1/{(gameCount / rbCount).toFixed(1)}</td>
+                  </tr>
+                  <tr>
+                    <th>合算確率</th>
+                    <td>1/{(gameCount / (bbCount + rbCount)).toFixed(1)}</td>
+                  </tr>
+                  <tr>
+                    <th>ぶどう確率</th>
+                    <td>1/{(gameCount / grapeCount).toFixed(2)}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+
+        <div className="reference-section">
+          <h3>{machine.name} - 設定別確率</h3>
+          <table className="reference-table">
+            <thead>
+              <tr>
+                <th>設定</th>
+                <th>BB</th>
+                <th>RB</th>
+                <th>合算</th>
+                <th>ぶどう</th>
+              </tr>
+            </thead>
+            <tbody>
+              {([1, 2, 3, 4, 5, 6] as SettingLevel[]).map((setting) => {
+                const prob = machine.settings[setting];
+                const bbProb = 1 / (1 / prob.singleBB + 1 / prob.cherryBB);
+                const rbProb = 1 / (1 / prob.singleRB + 1 / prob.cherryRB);
+                return (
+                  <tr key={setting}>
+                    <td>設定{setting}</td>
+                    <td>1/{bbProb.toFixed(1)}</td>
+                    <td>1/{rbProb.toFixed(1)}</td>
+                    <td>1/{getCombinedProbability(setting)}</td>
+                    <td>1/{prob.grape.toFixed(2)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </StyledEstimator>
+  );
+}

--- a/components/SettingEstimator/styled.tsx
+++ b/components/SettingEstimator/styled.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import styled from 'styled-components';
+
+const StyledEstimator = styled.div`
+  .container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 20px 16px 40px;
+  }
+
+  h1 {
+    text-align: center;
+    color: #00ff80;
+    font-size: 1.8em;
+    margin-bottom: 8px;
+  }
+
+  .description {
+    text-align: center;
+    color: #888;
+    margin-bottom: 24px;
+  }
+
+  .input-section {
+    background-color: #1a1a1a;
+    border-radius: 8px;
+    padding: 24px;
+    margin-bottom: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .input-group {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .input-group label {
+    width: 100px;
+    color: #aaa;
+    font-size: 0.95em;
+  }
+
+  .input-group input,
+  .input-group select {
+    flex: 1;
+    padding: 10px 12px;
+    font-size: 1em;
+    border: 1px solid #333;
+    border-radius: 6px;
+    background-color: #252525;
+    color: #e0e0e0;
+    transition: border-color 0.2s;
+  }
+
+  .input-group input:focus,
+  .input-group select:focus {
+    outline: none;
+    border-color: #00ff80;
+  }
+
+  .estimate-button {
+    display: block;
+    width: 100%;
+    font-size: 1.1em;
+    font-weight: bold;
+    padding: 14px;
+    color: #121212;
+    background: linear-gradient(135deg, #ffcc00 0%, #ff9900 100%);
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    box-shadow: 0 4px 15px rgba(255, 153, 0, 0.3);
+    margin-top: 8px;
+  }
+
+  .estimate-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(255, 153, 0, 0.4);
+  }
+
+  .results-section {
+    margin-bottom: 24px;
+  }
+
+  .results-table {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: #1a1a1a;
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 20px;
+  }
+
+  .results-table caption {
+    padding: 14px 16px;
+    font-size: 1.1em;
+    font-weight: bold;
+    color: #ffcc00;
+    background-color: #222;
+    text-align: left;
+    border-bottom: 1px solid #333;
+  }
+
+  .results-table th,
+  .results-table td {
+    padding: 12px 16px;
+    text-align: left;
+    border-bottom: 1px solid #333;
+  }
+
+  .results-table thead th {
+    background-color: #252525;
+    color: #aaa;
+    font-weight: normal;
+    font-size: 0.9em;
+  }
+
+  .results-table tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  .results-table tbody tr:hover {
+    background-color: rgba(255, 204, 0, 0.05);
+  }
+
+  .results-table .rank-1 {
+    background-color: rgba(255, 204, 0, 0.15);
+  }
+
+  .results-table .rank-1 .setting-cell {
+    color: #ffcc00;
+    font-weight: bold;
+  }
+
+  .results-table .rank-2 {
+    background-color: rgba(255, 204, 0, 0.08);
+  }
+
+  .setting-cell {
+    color: #e0e0e0;
+    font-weight: 500;
+  }
+
+  .probability-cell {
+    width: 40%;
+  }
+
+  .probability-bar-container {
+    position: relative;
+    height: 24px;
+    background-color: #333;
+    border-radius: 4px;
+    overflow: hidden;
+  }
+
+  .probability-bar {
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 100%;
+    background: linear-gradient(90deg, #ffcc00, #ff9900);
+    border-radius: 4px;
+    transition: width 0.3s ease;
+  }
+
+  .probability-value {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    font-weight: bold;
+    color: #fff;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    font-size: 0.9em;
+  }
+
+  .actual-data {
+    background-color: #1a1a1a;
+    border-radius: 8px;
+    padding: 16px;
+  }
+
+  .actual-data h3 {
+    color: #00ff80;
+    font-size: 1em;
+    margin-bottom: 12px;
+  }
+
+  .data-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .data-table th,
+  .data-table td {
+    padding: 8px 12px;
+    border-bottom: 1px solid #333;
+  }
+
+  .data-table th {
+    text-align: left;
+    color: #888;
+    font-weight: normal;
+    width: 40%;
+  }
+
+  .data-table td {
+    text-align: right;
+    color: #e0e0e0;
+  }
+
+  .data-table tr:last-child th,
+  .data-table tr:last-child td {
+    border-bottom: none;
+  }
+
+  .reference-section {
+    background-color: #1a1a1a;
+    border-radius: 8px;
+    padding: 16px;
+  }
+
+  .reference-section h3 {
+    color: #80d4ff;
+    font-size: 1em;
+    margin-bottom: 12px;
+  }
+
+  .reference-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9em;
+  }
+
+  .reference-table th,
+  .reference-table td {
+    padding: 8px 10px;
+    text-align: center;
+    border-bottom: 1px solid #333;
+  }
+
+  .reference-table thead th {
+    color: #888;
+    font-weight: normal;
+    background-color: #222;
+  }
+
+  .reference-table tbody td {
+    color: #ccc;
+  }
+
+  .reference-table tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  .reference-table tbody tr:hover {
+    background-color: rgba(128, 212, 255, 0.05);
+  }
+
+  @media screen and (max-width: 600px) {
+    .input-group {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .input-group label {
+      width: auto;
+      margin-bottom: 4px;
+    }
+
+    .input-group input,
+    .input-group select {
+      width: 100%;
+    }
+
+    .results-table th,
+    .results-table td {
+      padding: 10px 8px;
+      font-size: 0.9em;
+    }
+
+    .reference-table {
+      font-size: 0.8em;
+    }
+
+    .reference-table th,
+    .reference-table td {
+      padding: 6px 4px;
+    }
+  }
+`;
+
+export default StyledEstimator;


### PR DESCRIPTION
- 新規ページ /estimate を追加
- ベイズ推定による設定推測機能を実装
- 入力: 機種、回転数、BB回数、RB回数、ぶどう回数
- 出力: 各設定の推測確率（%）をバーグラフで表示
- 実データの確率と機種別設定確率の参照テーブルを表示
- ヘッダーナビゲーションを更新

https://claude.ai/code/session_01B8jzkieyAuC9FEoU9GEgg5