### PR TITLE
style: 全体のテーマを白ベースに変更

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -11,23 +11,23 @@ body {
   font-family: 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  background-color: #121212;
-  color: #e0e0e0;
+  background-color: #f5f5f5;
+  color: #333;
 }
 
 a {
-  color: #00ff80;
+  color: #0066cc;
   text-decoration: none;
   transition: color 0.2s ease;
 }
 
 a:hover {
-  color: #00cc66;
+  color: #004499;
 }
 
 ::selection {
-  background-color: #00ff80;
-  color: #121212;
+  background-color: #0066cc;
+  color: #fff;
 }
 
 ::-webkit-scrollbar {
@@ -35,14 +35,14 @@ a:hover {
 }
 
 ::-webkit-scrollbar-track {
-  background: #1a1a1a;
+  background: #e0e0e0;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #333;
+  background: #999;
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #444;
+  background: #777;
 }

--- a/components/Footer/styled.tsx
+++ b/components/Footer/styled.tsx
@@ -4,9 +4,9 @@ import styled from 'styled-components';
 
 const StyledFooter = styled.div`
   footer {
-    background: linear-gradient(180deg, #171717 0%, #121212 100%);
-    border-top: 1px solid #2a2a2a;
-    color: #888;
+    background: linear-gradient(180deg, #f8f8f8 0%, #f0f0f0 100%);
+    border-top: 1px solid #e0e0e0;
+    color: #666;
     padding: 24px 0;
     text-align: center;
     font-size: 13px;
@@ -14,19 +14,19 @@ const StyledFooter = styled.div`
   }
 
   footer a {
-    color: #aaa;
+    color: #555;
     text-decoration: none;
     margin: 0 12px;
     transition: color 0.2s ease;
   }
 
   footer a:hover {
-    color: #00ff80;
+    color: #d4af37;
   }
 
   footer p {
     margin-top: 16px;
-    color: #666;
+    color: #888;
   }
 
   footer ul {

--- a/components/Graphs/index.tsx
+++ b/components/Graphs/index.tsx
@@ -331,10 +331,10 @@ export default function Graphs({ game, machineId, setting, trialCount }: Props) 
           data: results,
           fill: {
             target: 'origin',
-            above: 'rgba(0, 255, 128, 0.15)',
-            below: 'rgba(255, 80, 80, 0.15)',
+            above: 'rgba(46, 125, 50, 0.15)',
+            below: 'rgba(198, 40, 40, 0.15)',
           },
-          borderColor: '#00ff80',
+          borderColor: '#2e7d32',
           borderWidth: 2,
           pointRadius: 0,
           tension: 0,
@@ -347,10 +347,10 @@ export default function Graphs({ game, machineId, setting, trialCount }: Props) 
       const finalValue = graphData[graphData.length - 1]?.y || 0;
       const isPositive = finalValue >= 0;
       // 透明度を調整（試行回数が多いほど薄く）
-      const opacity = Math.max(0.1, Math.min(0.6, 30 / trialCount));
+      const opacity = Math.max(0.2, Math.min(0.7, 40 / trialCount));
       const color = isPositive
-        ? `rgba(0, 255, 128, ${opacity})`
-        : `rgba(255, 80, 80, ${opacity})`;
+        ? `rgba(46, 125, 50, ${opacity})`
+        : `rgba(198, 40, 40, ${opacity})`;
 
       return {
         label: `試行${index + 1}`,
@@ -387,14 +387,14 @@ export default function Graphs({ game, machineId, setting, trialCount }: Props) 
         title: {
           display: true,
           text: '回転数',
-          color: '#aaa',
+          color: '#666',
           font: { size: 12 },
         },
         grid: {
-          color: 'rgba(255, 255, 255, 0.1)',
+          color: 'rgba(0, 0, 0, 0.1)',
         },
         ticks: {
-          color: '#aaa',
+          color: '#666',
           maxTicksLimit: 10,
         },
       },
@@ -403,15 +403,15 @@ export default function Graphs({ game, machineId, setting, trialCount }: Props) 
         title: {
           display: true,
           text: '差枚数',
-          color: '#aaa',
+          color: '#666',
           font: { size: 12 },
         },
         grid: {
           color: (context: { tick: { value: number } }) => {
             if (context.tick.value === 0) {
-              return 'rgba(255, 255, 255, 0.5)';
+              return 'rgba(0, 0, 0, 0.4)';
             }
-            return 'rgba(255, 255, 255, 0.1)';
+            return 'rgba(0, 0, 0, 0.1)';
           },
           lineWidth: (context: { tick: { value: number } }) => {
             if (context.tick.value === 0) {
@@ -421,7 +421,7 @@ export default function Graphs({ game, machineId, setting, trialCount }: Props) 
           },
         },
         ticks: {
-          color: '#aaa',
+          color: '#666',
         },
       },
     },

--- a/components/Graphs/styled.tsx
+++ b/components/Graphs/styled.tsx
@@ -24,89 +24,91 @@ const StyledGraphs = styled.div`
     font-size: 1.1em;
     font-weight: bold;
     padding: 14px 32px;
-    color: #121212;
-    background: linear-gradient(135deg, #00ff80 0%, #00cc66 100%);
+    color: #fff;
+    background: linear-gradient(135deg, #d4af37 0%, #b8972e 100%);
     border: none;
     border-radius: 6px;
     cursor: pointer;
     transition: all 0.2s ease;
-    box-shadow: 0 4px 15px rgba(0, 255, 128, 0.3);
+    box-shadow: 0 4px 15px rgba(212, 175, 55, 0.3);
   }
 
   .styled-button:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(0, 255, 128, 0.4);
+    box-shadow: 0 6px 20px rgba(212, 175, 55, 0.4);
   }
 
   .styled-button:active {
     transform: translateY(0);
-    box-shadow: 0 2px 10px rgba(0, 255, 128, 0.3);
+    box-shadow: 0 2px 10px rgba(212, 175, 55, 0.3);
   }
 
   .styled-button.multi {
-    background: linear-gradient(135deg, #80d4ff 0%, #4db8ff 100%);
-    box-shadow: 0 4px 15px rgba(77, 184, 255, 0.3);
+    background: linear-gradient(135deg, #5a9fd4 0%, #4a8bc4 100%);
+    box-shadow: 0 4px 15px rgba(90, 159, 212, 0.3);
   }
 
   .styled-button.multi:hover {
-    box-shadow: 0 6px 20px rgba(77, 184, 255, 0.4);
+    box-shadow: 0 6px 20px rgba(90, 159, 212, 0.4);
   }
 
   .styled-button.multi:active {
-    box-shadow: 0 2px 10px rgba(77, 184, 255, 0.3);
+    box-shadow: 0 2px 10px rgba(90, 159, 212, 0.3);
   }
 
   .graph {
     width: 90%;
     max-width: 800px;
     height: 400px;
-    background-color: #1a1a1a;
+    background-color: #fff;
     border-radius: 8px;
     padding: 20px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+    border: 1px solid #e0e0e0;
   }
 
   .styled-table {
     border-collapse: collapse;
     width: 90%;
     max-width: 500px;
-    background-color: #1a1a1a;
+    background-color: #fff;
     border-radius: 8px;
     overflow: hidden;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+    border: 1px solid #e0e0e0;
   }
 
   .styled-table caption {
     padding: 14px 16px;
     font-size: 1.1em;
     font-weight: bold;
-    color: #00ff80;
-    background-color: #222;
+    color: #d4af37;
+    background-color: #fafafa;
     text-align: left;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid #e0e0e0;
   }
 
   .styled-table th {
     padding: 10px 16px;
-    background-color: #252525;
-    color: #aaa;
+    background-color: #f5f5f5;
+    color: #666;
     font-weight: normal;
     text-align: left;
     width: 40%;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid #e0e0e0;
   }
 
   .styled-table td {
     padding: 10px 16px;
     text-align: right;
-    color: #e0e0e0;
-    border-bottom: 1px solid #333;
+    color: #333;
+    border-bottom: 1px solid #e0e0e0;
   }
 
   .styled-table thead th,
   .styled-table thead td {
-    background-color: #222;
-    color: #888;
+    background-color: #fafafa;
+    color: #666;
     font-size: 0.85em;
     padding: 8px 16px;
   }
@@ -117,31 +119,31 @@ const StyledGraphs = styled.div`
   }
 
   .styled-table tbody tr:hover {
-    background-color: rgba(0, 255, 128, 0.05);
+    background-color: rgba(212, 175, 55, 0.05);
   }
 
   .stats-table {
-    border: 2px solid #4db8ff;
+    border: 2px solid #5a9fd4;
   }
 
   .stats-table caption {
-    color: #80d4ff;
+    color: #5a9fd4;
   }
 
   .positive {
-    color: #00ff80 !important;
+    color: #2e7d32 !important;
   }
 
   .negative {
-    color: #ff6b6b !important;
+    color: #c62828 !important;
   }
 
   .error-message {
-    color: #ff6b6b !important;
-    background-color: rgba(255, 107, 107, 0.1);
+    color: #c62828 !important;
+    background-color: rgba(198, 40, 40, 0.1);
     padding: 12px 20px;
     border-radius: 6px;
-    border: 1px solid rgba(255, 107, 107, 0.3);
+    border: 1px solid rgba(198, 40, 40, 0.3);
   }
 
   @media screen and (max-width: 600px) {

--- a/components/Header/styled.tsx
+++ b/components/Header/styled.tsx
@@ -8,17 +8,16 @@ const StyledHeader = styled.div`
     justify-content: space-between;
     align-items: center;
     padding: 16px 24px;
-    background: linear-gradient(180deg, #1f1f1f 0%, #171717 100%);
-    border-bottom: 1px solid #2a2a2a;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+    background: linear-gradient(180deg, #fff 0%, #f8f8f8 100%);
+    border-bottom: 1px solid #e0e0e0;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   }
 
   .title h1 {
     margin: 0;
     font-size: 1.5em;
     font-weight: bold;
-    color: #00ff80;
-    text-shadow: 0 0 10px rgba(0, 255, 128, 0.3);
+    color: #d4af37;
   }
 
   .title p {
@@ -38,15 +37,15 @@ const StyledHeader = styled.div`
     display: block;
     padding: 8px 16px;
     text-decoration: none;
-    color: #aaa;
+    color: #555;
     font-size: 0.9em;
     border-radius: 4px;
     transition: all 0.2s ease;
   }
 
   .menu ul li a:hover {
-    color: #00ff80;
-    background-color: rgba(0, 255, 128, 0.1);
+    color: #d4af37;
+    background-color: rgba(212, 175, 55, 0.1);
   }
 
   @media screen and (max-width: 768px) {

--- a/components/Menu/styled.tsx
+++ b/components/Menu/styled.tsx
@@ -12,35 +12,36 @@ const StyledMenu = styled.div`
     border-collapse: collapse;
     font-size: 0.95em;
     min-width: 320px;
-    background-color: #1a1a1a;
+    background-color: #fff;
     border-radius: 8px;
     overflow: hidden;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+    border: 1px solid #e0e0e0;
   }
 
   .styled-table caption {
     padding: 16px;
     font-size: 1.1em;
     font-weight: bold;
-    color: #00ff80;
-    background-color: #222;
+    color: #d4af37;
+    background-color: #fafafa;
     text-align: left;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid #e0e0e0;
   }
 
   .styled-table th {
     padding: 12px 16px;
-    background-color: #252525;
-    color: #aaa;
+    background-color: #f5f5f5;
+    color: #666;
     font-weight: normal;
     text-align: left;
     width: 120px;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid #e0e0e0;
   }
 
   .styled-table td {
     padding: 12px 16px;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid #e0e0e0;
   }
 
   .styled-table tbody tr:last-child th,
@@ -53,32 +54,32 @@ const StyledMenu = styled.div`
     width: 100%;
     padding: 10px 12px;
     font-size: 1em;
-    background-color: #2a2a2a;
-    border: 1px solid #444;
+    background-color: #fff;
+    border: 1px solid #ccc;
     border-radius: 4px;
-    color: #fff;
+    color: #333;
     outline: none;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
   }
 
   .styled-table select:focus,
   .styled-table input:focus {
-    border-color: #00ff80;
-    box-shadow: 0 0 0 2px rgba(0, 255, 128, 0.2);
+    border-color: #d4af37;
+    box-shadow: 0 0 0 2px rgba(212, 175, 55, 0.2);
   }
 
   .styled-table select {
     cursor: pointer;
     appearance: none;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23888' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23666' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
     background-position: right 12px center;
     padding-right: 36px;
   }
 
   .styled-table select option {
-    background-color: #2a2a2a;
-    color: #fff;
+    background-color: #fff;
+    color: #333;
   }
 
   .styled-table input[type='number'] {

--- a/components/SettingEstimator/styled.tsx
+++ b/components/SettingEstimator/styled.tsx
@@ -11,25 +11,27 @@ const StyledEstimator = styled.div`
 
   h1 {
     text-align: center;
-    color: #00ff80;
+    color: #d4af37;
     font-size: 1.8em;
     margin-bottom: 8px;
   }
 
   .description {
     text-align: center;
-    color: #888;
+    color: #666;
     margin-bottom: 24px;
   }
 
   .input-section {
-    background-color: #1a1a1a;
+    background-color: #fff;
     border-radius: 8px;
     padding: 24px;
     margin-bottom: 24px;
     display: flex;
     flex-direction: column;
     gap: 16px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+    border: 1px solid #e0e0e0;
   }
 
   .input-group {
@@ -40,7 +42,7 @@ const StyledEstimator = styled.div`
 
   .input-group label {
     width: 100px;
-    color: #aaa;
+    color: #555;
     font-size: 0.95em;
   }
 
@@ -49,17 +51,17 @@ const StyledEstimator = styled.div`
     flex: 1;
     padding: 10px 12px;
     font-size: 1em;
-    border: 1px solid #333;
+    border: 1px solid #ccc;
     border-radius: 6px;
-    background-color: #252525;
-    color: #e0e0e0;
+    background-color: #fff;
+    color: #333;
     transition: border-color 0.2s;
   }
 
   .input-group input:focus,
   .input-group select:focus {
     outline: none;
-    border-color: #00ff80;
+    border-color: #d4af37;
   }
 
   .estimate-button {
@@ -68,19 +70,19 @@ const StyledEstimator = styled.div`
     font-size: 1.1em;
     font-weight: bold;
     padding: 14px;
-    color: #121212;
-    background: linear-gradient(135deg, #ffcc00 0%, #ff9900 100%);
+    color: #fff;
+    background: linear-gradient(135deg, #ff9800 0%, #f57c00 100%);
     border: none;
     border-radius: 6px;
     cursor: pointer;
     transition: all 0.2s ease;
-    box-shadow: 0 4px 15px rgba(255, 153, 0, 0.3);
+    box-shadow: 0 4px 15px rgba(255, 152, 0, 0.3);
     margin-top: 8px;
   }
 
   .estimate-button:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(255, 153, 0, 0.4);
+    box-shadow: 0 6px 20px rgba(255, 152, 0, 0.4);
   }
 
   .results-section {
@@ -90,32 +92,34 @@ const StyledEstimator = styled.div`
   .results-table {
     width: 100%;
     border-collapse: collapse;
-    background-color: #1a1a1a;
+    background-color: #fff;
     border-radius: 8px;
     overflow: hidden;
     margin-bottom: 20px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+    border: 1px solid #e0e0e0;
   }
 
   .results-table caption {
     padding: 14px 16px;
     font-size: 1.1em;
     font-weight: bold;
-    color: #ffcc00;
-    background-color: #222;
+    color: #ff9800;
+    background-color: #fafafa;
     text-align: left;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid #e0e0e0;
   }
 
   .results-table th,
   .results-table td {
     padding: 12px 16px;
     text-align: left;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid #e0e0e0;
   }
 
   .results-table thead th {
-    background-color: #252525;
-    color: #aaa;
+    background-color: #f5f5f5;
+    color: #666;
     font-weight: normal;
     font-size: 0.9em;
   }
@@ -125,24 +129,24 @@ const StyledEstimator = styled.div`
   }
 
   .results-table tbody tr:hover {
-    background-color: rgba(255, 204, 0, 0.05);
+    background-color: rgba(255, 152, 0, 0.05);
   }
 
   .results-table .rank-1 {
-    background-color: rgba(255, 204, 0, 0.15);
+    background-color: rgba(255, 152, 0, 0.15);
   }
 
   .results-table .rank-1 .setting-cell {
-    color: #ffcc00;
+    color: #e65100;
     font-weight: bold;
   }
 
   .results-table .rank-2 {
-    background-color: rgba(255, 204, 0, 0.08);
+    background-color: rgba(255, 152, 0, 0.08);
   }
 
   .setting-cell {
-    color: #e0e0e0;
+    color: #333;
     font-weight: 500;
   }
 
@@ -153,7 +157,7 @@ const StyledEstimator = styled.div`
   .probability-bar-container {
     position: relative;
     height: 24px;
-    background-color: #333;
+    background-color: #e0e0e0;
     border-radius: 4px;
     overflow: hidden;
   }
@@ -163,7 +167,7 @@ const StyledEstimator = styled.div`
     left: 0;
     top: 0;
     height: 100%;
-    background: linear-gradient(90deg, #ffcc00, #ff9900);
+    background: linear-gradient(90deg, #ff9800, #f57c00);
     border-radius: 4px;
     transition: width 0.3s ease;
   }
@@ -174,19 +178,21 @@ const StyledEstimator = styled.div`
     top: 50%;
     transform: translate(-50%, -50%);
     font-weight: bold;
-    color: #fff;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    color: #333;
+    text-shadow: 0 1px 2px rgba(255, 255, 255, 0.8);
     font-size: 0.9em;
   }
 
   .actual-data {
-    background-color: #1a1a1a;
+    background-color: #fff;
     border-radius: 8px;
     padding: 16px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+    border: 1px solid #e0e0e0;
   }
 
   .actual-data h3 {
-    color: #00ff80;
+    color: #2e7d32;
     font-size: 1em;
     margin-bottom: 12px;
   }
@@ -199,19 +205,19 @@ const StyledEstimator = styled.div`
   .data-table th,
   .data-table td {
     padding: 8px 12px;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid #e0e0e0;
   }
 
   .data-table th {
     text-align: left;
-    color: #888;
+    color: #666;
     font-weight: normal;
     width: 40%;
   }
 
   .data-table td {
     text-align: right;
-    color: #e0e0e0;
+    color: #333;
   }
 
   .data-table tr:last-child th,
@@ -220,13 +226,15 @@ const StyledEstimator = styled.div`
   }
 
   .reference-section {
-    background-color: #1a1a1a;
+    background-color: #fff;
     border-radius: 8px;
     padding: 16px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+    border: 1px solid #e0e0e0;
   }
 
   .reference-section h3 {
-    color: #80d4ff;
+    color: #5a9fd4;
     font-size: 1em;
     margin-bottom: 12px;
   }
@@ -241,17 +249,17 @@ const StyledEstimator = styled.div`
   .reference-table td {
     padding: 8px 10px;
     text-align: center;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid #e0e0e0;
   }
 
   .reference-table thead th {
-    color: #888;
+    color: #666;
     font-weight: normal;
-    background-color: #222;
+    background-color: #f5f5f5;
   }
 
   .reference-table tbody td {
-    color: #ccc;
+    color: #444;
   }
 
   .reference-table tbody tr:last-child td {
@@ -259,7 +267,7 @@ const StyledEstimator = styled.div`
   }
 
   .reference-table tbody tr:hover {
-    background-color: rgba(128, 212, 255, 0.05);
+    background-color: rgba(90, 159, 212, 0.05);
   }
 
   @media screen and (max-width: 600px) {


### PR DESCRIPTION
- globals.css: 背景を白系に、テキストを暗い色に変更
- Header/Footer: 白背景にゴールドのアクセントカラー
- Menu/Graphs/SettingEstimator: 白背景のカード風デザイン
- グラフ: 軸とグリッドの色を白背景用に調整
- プラスは緑、マイナスは赤の配色を維持

https://claude.ai/code/session_01B8jzkieyAuC9FEoU9GEgg5